### PR TITLE
feat: Convert to Integram template format

### DIFF
--- a/templates/process.css
+++ b/templates/process.css
@@ -1,0 +1,307 @@
+/**
+ * Process List Styles
+ * Template for Integram Constructor
+ */
+
+/* Notification Panel */
+.notification-panel {
+    position: fixed;
+    top: 70px;
+    left: 50%;
+    transform: translateX(-50%) translateY(-100%);
+    background-color: #d4edda;
+    border: 2px solid #90ee90;
+    color: #155724;
+    padding: 12px 24px;
+    border-radius: 8px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    z-index: 10000;
+    min-width: 280px;
+    max-width: 90%;
+    text-align: center;
+    font-size: 14px;
+    transition: transform 0.3s ease-in-out, opacity 0.3s ease-in-out;
+    opacity: 0;
+    visibility: hidden;
+}
+
+.notification-panel.show {
+    transform: translateX(-50%) translateY(0);
+    opacity: 1;
+    visibility: visible;
+}
+
+.notification-panel.error {
+    background-color: #f8d7da;
+    border-color: #f5c6cb;
+    color: #721c24;
+}
+
+.notification-panel.success {
+    background-color: #d4edda;
+    border-color: #c3e6cb;
+    color: #155724;
+}
+
+.notification-panel.warning {
+    background-color: #fff3cd;
+    border-color: #ffeeba;
+    color: #856404;
+}
+
+.notification-panel.info {
+    background-color: #d1ecf1;
+    border-color: #bee5eb;
+    color: #0c5460;
+}
+
+/* Process Card Styles */
+.process-card {
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    border-left: 4px solid #007bff;
+}
+
+.process-card:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.12);
+}
+
+.process-title {
+    font-size: 1rem;
+    font-weight: 600;
+    text-decoration: none;
+    cursor: pointer;
+    display: block;
+    word-break: break-word;
+}
+
+.process-title:hover {
+    text-decoration: underline;
+}
+
+.process-id {
+    font-size: 0.75rem;
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
+.process-details p {
+    font-size: 0.875rem;
+    line-height: 1.4;
+}
+
+.process-details .text-muted {
+    font-weight: 400;
+}
+
+/* Search Container */
+.search-container {
+    display: flex;
+    align-items: center;
+}
+
+.search-container input {
+    border-radius: 20px;
+    padding: 8px 16px;
+    border: 1px solid #ddd;
+    transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.search-container input:focus {
+    border-color: #007bff;
+    box-shadow: 0 0 0 3px rgba(0, 123, 255, 0.15);
+    outline: none;
+}
+
+/* Pagination */
+.pagination .page-link {
+    border-radius: 4px;
+    margin: 0 2px;
+    padding: 8px 14px;
+    transition: all 0.2s;
+}
+
+.pagination .page-item.active .page-link {
+    background-color: #007bff;
+    border-color: #007bff;
+}
+
+/* Modal Styles */
+.modal-lg {
+    max-width: 700px;
+}
+
+.modal-header {
+    background-color: #f8f9fa;
+    border-bottom: 1px solid #e9ecef;
+}
+
+.nav-tabs .nav-link {
+    color: #495057;
+    border: none;
+    border-bottom: 2px solid transparent;
+    padding: 10px 16px;
+    transition: all 0.2s;
+}
+
+.nav-tabs .nav-link:hover {
+    color: #007bff;
+    border-color: transparent;
+}
+
+.nav-tabs .nav-link.active {
+    color: #007bff;
+    border-bottom-color: #007bff;
+    background: transparent;
+}
+
+.tab-content {
+    min-height: 300px;
+}
+
+/* Form Styles */
+.form-group label {
+    font-weight: 500;
+    font-size: 0.875rem;
+    color: #333;
+}
+
+.form-control {
+    border-radius: 6px;
+    border: 1px solid #ced4da;
+    transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.form-control:focus {
+    border-color: #007bff;
+    box-shadow: 0 0 0 3px rgba(0, 123, 255, 0.15);
+}
+
+textarea.form-control {
+    resize: vertical;
+    min-height: 70px;
+}
+
+select.form-control[multiple] {
+    min-height: 120px;
+}
+
+/* Loading State */
+.spinner-border {
+    width: 2.5rem;
+    height: 2.5rem;
+}
+
+/* Button Styles */
+.btn-primary {
+    background-color: #007bff;
+    border-color: #007bff;
+    transition: all 0.2s;
+}
+
+.btn-primary:hover {
+    background-color: #0069d9;
+    border-color: #0062cc;
+    transform: translateY(-1px);
+}
+
+/* Card Header */
+.card-header {
+    background-color: #fff;
+    border-bottom: 1px solid #e9ecef;
+    padding: 16px 20px;
+}
+
+.card-header h4 {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: #333;
+}
+
+/* Empty States */
+#emptyState,
+#noResultsState {
+    color: #6c757d;
+}
+
+#emptyState p,
+#noResultsState p {
+    font-size: 1rem;
+    margin: 0;
+}
+
+/* Items Counter */
+#itemsCounter {
+    font-size: 0.875rem;
+}
+
+/* Responsive Styles */
+@media (max-width: 768px) {
+    .card-header {
+        flex-direction: column;
+        align-items: stretch !important;
+    }
+
+    .card-header h4 {
+        text-align: center;
+        margin-bottom: 12px;
+    }
+
+    .card-header .d-flex {
+        flex-direction: column;
+        width: 100%;
+    }
+
+    .search-container {
+        width: 100%;
+        margin-bottom: 12px;
+    }
+
+    .search-container input {
+        width: 100%;
+        min-width: auto !important;
+    }
+
+    .card-header .btn {
+        width: 100%;
+    }
+
+    .nav-tabs {
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+
+    .nav-tabs .nav-link {
+        white-space: nowrap;
+        padding: 8px 12px;
+        font-size: 0.875rem;
+    }
+
+    .modal-dialog {
+        margin: 10px;
+    }
+
+    .process-card-col {
+        padding-left: 10px;
+        padding-right: 10px;
+    }
+}
+
+@media (max-width: 576px) {
+    .pagination .page-link {
+        padding: 6px 10px;
+        font-size: 0.875rem;
+    }
+
+    .process-details p {
+        font-size: 0.8125rem;
+    }
+}
+
+/* Bootstrap Icon placeholder (if not using Bootstrap Icons) */
+.bi-plus-circle::before {
+    content: "+";
+    font-weight: bold;
+}

--- a/templates/process.html
+++ b/templates/process.html
@@ -1,0 +1,215 @@
+<link rel="stylesheet" href="/download/{_global_.z}/process.css" />
+<script src="/download/{_global_.z}/process.js"></script>
+
+<!-- Notification Panel -->
+<div id="notificationPanel" class="notification-panel">
+    <span id="notificationMessage"></span>
+</div>
+
+<div class="container-fluid pt-4">
+    <div class="row">
+        <div class="col-12">
+            <div class="card">
+                <div class="card-header d-flex justify-content-between align-items-center flex-wrap">
+                    <h4 class="mb-2 mb-md-0">Процессы обработки ПДн</h4>
+                    <div class="d-flex align-items-center flex-wrap">
+                        <div class="search-container mr-3 mb-2 mb-md-0">
+                            <input type="text"
+                                   class="form-control"
+                                   id="searchInput"
+                                   placeholder="Поиск по любому полю..."
+                                   style="min-width: 250px;">
+                        </div>
+                        <button class="btn btn-primary" onclick="openAddForm()">
+                            <i class="bi bi-plus-circle mr-1"></i> Добавить
+                        </button>
+                    </div>
+                </div>
+                <div class="card-body">
+                    <!-- Loading State -->
+                    <div id="loadingState" class="text-center py-5">
+                        <div class="spinner-border text-primary" role="status">
+                            <span class="sr-only">Загрузка...</span>
+                        </div>
+                        <p class="mt-3 text-muted">Загрузка процессов...</p>
+                    </div>
+
+                    <!-- Process Cards Grid -->
+                    <div id="processGrid" class="row" style="display: none;"></div>
+
+                    <!-- Empty State -->
+                    <div id="emptyState" class="text-center py-5" style="display: none;">
+                        <p class="text-muted">Список процессов пуст</p>
+                    </div>
+
+                    <!-- No Results State -->
+                    <div id="noResultsState" class="text-center py-5" style="display: none;">
+                        <p class="text-muted">Ничего не найдено по запросу "<span id="searchQuery"></span>"</p>
+                    </div>
+
+                    <!-- Pagination -->
+                    <nav id="paginationNav" aria-label="Навигация по страницам" style="display: none;">
+                        <ul class="pagination justify-content-center mt-4" id="pagination"></ul>
+                    </nav>
+
+                    <!-- Items Counter -->
+                    <div id="itemsCounter" class="text-center text-muted mt-3" style="display: none;"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Process Card Template -->
+<template id="processCardTemplate">
+    <div class="col-lg-4 col-md-6 col-sm-12 mb-3 process-card-col">
+        <div class="card process-card h-100">
+            <div class="card-body">
+                <div class="d-flex justify-content-between align-items-start mb-2">
+                    <a href="#" class="process-title text-primary font-weight-bold" onclick="openEditForm(this); return false;" data-process-id=""></a>
+                    <small class="text-muted process-id"></small>
+                </div>
+                <div class="process-details">
+                    <p class="mb-1"><span class="text-muted">Группа:</span> <span class="process-group">—</span></p>
+                    <p class="mb-1"><span class="text-muted">Кол-во субъектов:</span> <span class="process-subjects">—</span></p>
+                    <p class="mb-1"><span class="text-muted">Дата создания:</span> <span class="process-date">—</span></p>
+                    <p class="mb-0"><span class="text-muted">Создатель:</span> <span class="process-creator">—</span></p>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<!-- Process Form Modal -->
+<div class="modal fade" id="processFormModal" tabindex="-1" role="dialog" aria-labelledby="processFormModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="processFormModalLabel">Новый процесс</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <!-- Tabs -->
+                <ul class="nav nav-tabs" id="formTabs" role="tablist">
+                    <li class="nav-item">
+                        <a class="nav-link active" id="general-tab" data-toggle="tab" href="#generalTab" role="tab">Общая информация</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" id="is-tab" data-toggle="tab" href="#isTab" role="tab">ИС</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" id="purpose-tab" data-toggle="tab" href="#purposeTab" role="tab">Цель обработки</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" id="method-tab" data-toggle="tab" href="#methodTab" role="tab">Способ обработки</a>
+                    </li>
+                </ul>
+
+                <!-- Tab Content -->
+                <div class="tab-content pt-3" id="formTabContent">
+                    <!-- Общая информация -->
+                    <div class="tab-pane fade show active" id="generalTab" role="tabpanel">
+                        <div class="form-group">
+                            <label for="processName">Процесс *</label>
+                            <textarea class="form-control" id="processName" rows="2" placeholder="Название процесса"></textarea>
+                        </div>
+                        <div class="form-group">
+                            <label for="processStatus">Статус</label>
+                            <select class="form-control" id="processStatus"></select>
+                        </div>
+                        <div class="form-group">
+                            <label for="processGroup">Группа</label>
+                            <select class="form-control" id="processGroup"></select>
+                        </div>
+                        <div class="form-group">
+                            <label for="processParent">Родительский процесс</label>
+                            <select class="form-control" id="processParent"></select>
+                        </div>
+                        <div class="form-group">
+                            <label for="processInitiator">Инициатор</label>
+                            <select class="form-control" id="processInitiator"></select>
+                        </div>
+                    </div>
+
+                    <!-- ИС -->
+                    <div class="tab-pane fade" id="isTab" role="tabpanel">
+                        <div class="form-group">
+                            <label for="processProduct">Продукт</label>
+                            <select class="form-control" id="processProduct"></select>
+                        </div>
+                        <div class="form-group">
+                            <label for="processService">Сервис</label>
+                            <select class="form-control" id="processService"></select>
+                        </div>
+                        <div class="form-group">
+                            <label for="processIS">ИС</label>
+                            <select class="form-control" id="processIS"></select>
+                        </div>
+                    </div>
+
+                    <!-- Цель обработки -->
+                    <div class="tab-pane fade" id="purposeTab" role="tabpanel">
+                        <div class="form-group">
+                            <label for="processPurpose">Цель обработки ПДн</label>
+                            <select class="form-control" id="processPurpose"></select>
+                        </div>
+                        <div class="form-group">
+                            <label for="processMicroPurpose">Микроцель обработки ПДн</label>
+                            <select class="form-control" id="processMicroPurpose"></select>
+                        </div>
+                        <div class="form-group">
+                            <label for="processSubjectCategories">Категории субъектов ПДн</label>
+                            <select class="form-control" id="processSubjectCategories" multiple size="5"></select>
+                            <small class="form-text text-muted">Удерживайте Ctrl для выбора нескольких</small>
+                        </div>
+                        <div class="form-group">
+                            <label for="processSubjectsCount">Количество субъектов ПДн</label>
+                            <select class="form-control" id="processSubjectsCount"></select>
+                        </div>
+                        <div class="form-group">
+                            <label for="processLegalBasis">Основание обработки ПДн</label>
+                            <select class="form-control" id="processLegalBasis"></select>
+                        </div>
+                        <div class="form-group">
+                            <label for="processLegalAct">Реквизиты нормативного правового акта</label>
+                            <textarea class="form-control" id="processLegalAct" rows="2" placeholder="Введите реквизиты"></textarea>
+                        </div>
+                    </div>
+
+                    <!-- Способ обработки -->
+                    <div class="tab-pane fade" id="methodTab" role="tabpanel">
+                        <div class="form-group">
+                            <label for="processMethod">Способ обработки ПДн</label>
+                            <select class="form-control" id="processMethod"></select>
+                        </div>
+                        <div class="form-group">
+                            <label for="processTerm">Срок обработки ПДн</label>
+                            <select class="form-control" id="processTerm"></select>
+                        </div>
+                        <div class="form-group">
+                            <label for="processDestruction">Порядок уничтожения ПДн</label>
+                            <textarea class="form-control" id="processDestruction" rows="2" placeholder="Опишите порядок уничтожения"></textarea>
+                        </div>
+                        <div class="form-group">
+                            <label for="processDestructionFile">Порядок уничтожения (файл)</label>
+                            <input type="file" class="form-control-file" id="processDestructionFile">
+                            <small class="form-text text-muted">Загрузка файлов в данной версии не поддерживается</small>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Error Message -->
+                <div id="formError" class="alert alert-danger mt-3" style="display: none;"></div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Отмена</button>
+                <button type="button" class="btn btn-primary" id="saveProcessBtn" onclick="saveProcess()">
+                    <span class="spinner-border spinner-border-sm d-none" role="status"></span>
+                    <span class="btn-text">Сохранить</span>
+                </button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/templates/process.js
+++ b/templates/process.js
@@ -1,0 +1,616 @@
+/**
+ * Process List - Personal Data Processing Management
+ * Template for Integram Constructor
+ */
+
+// Global state
+let allProcesses = [];
+let filteredProcesses = [];
+let currentPage = 1;
+const itemsPerPage = 20;
+let references = {};
+let editingProcessId = null;
+let referencesLoaded = false;
+
+// Field mappings for API
+const FIELD_IDS = {
+    process: 't294',
+    status: 't297',
+    group: 't300',
+    parent: 't302',
+    initiator: 't365',
+    product: 't305',
+    service: 't313',
+    is: 't319',
+    purpose: 't326',
+    microPurpose: 't329',
+    subjectCategories: 't392',
+    subjectsCount: 't333',
+    legalBasis: 't336',
+    legalAct: 't338',
+    method: 't347',
+    term: 't350',
+    destruction: 't352',
+    destructionFile: 't354'
+};
+
+// Reference field names for API calls
+const REFERENCE_NAMES = [
+    'Статус',
+    'Группа',
+    'Инициатор',
+    'Продукт',
+    'Сервис',
+    'ИС',
+    'Цель обработки ПДн',
+    'Микроцель обработки ПДн',
+    'Категории субъектов ПДн',
+    'Количество субъектов ПДн',
+    'Основание обработки ПДн',
+    'Способ обработки ПДн',
+    'Срок обработки ПДн'
+];
+
+// Initialize on page load
+$(document).ready(function() {
+    // Check if user is guest and redirect to login
+    if (typeof uid === 'undefined' || uid === '' || uid === 'guest') {
+        window.location.href = '/' + db + '/login';
+        return;
+    }
+
+    loadProcesses();
+    setupSearchListener();
+});
+
+/**
+ * Load processes from API
+ */
+function loadProcesses() {
+    showLoadingState();
+
+    $.ajax({
+        url: '/' + db + '/report/480?JSON_KV',
+        method: 'GET',
+        dataType: 'json',
+        success: function(data) {
+            allProcesses = data || [];
+            filteredProcesses = allProcesses;
+            renderProcesses();
+            hideLoadingState();
+        },
+        error: function(xhr, status, error) {
+            console.error('Error loading processes:', error);
+            showNotification('Ошибка загрузки процессов: ' + error, 'error');
+            hideLoadingState();
+            $('#emptyState').show();
+        }
+    });
+}
+
+/**
+ * Render processes grid with pagination
+ */
+function renderProcesses() {
+    const grid = $('#processGrid');
+    const emptyState = $('#emptyState');
+    const noResults = $('#noResultsState');
+    const pagination = $('#paginationNav');
+    const counter = $('#itemsCounter');
+
+    grid.empty();
+
+    if (filteredProcesses.length === 0) {
+        grid.hide();
+        pagination.hide();
+        counter.hide();
+
+        if ($('#searchInput').val().trim()) {
+            $('#searchQuery').text($('#searchInput').val());
+            noResults.show();
+            emptyState.hide();
+        } else {
+            emptyState.show();
+            noResults.hide();
+        }
+        return;
+    }
+
+    emptyState.hide();
+    noResults.hide();
+    grid.show();
+
+    // Calculate pagination
+    const totalPages = Math.ceil(filteredProcesses.length / itemsPerPage);
+    const startIndex = (currentPage - 1) * itemsPerPage;
+    const endIndex = Math.min(startIndex + itemsPerPage, filteredProcesses.length);
+    const pageProcesses = filteredProcesses.slice(startIndex, endIndex);
+
+    // Render cards
+    const template = document.getElementById('processCardTemplate');
+    pageProcesses.forEach(function(process) {
+        const clone = template.content.cloneNode(true);
+        const card = clone.querySelector('.process-card-col');
+
+        // Set data
+        const titleEl = card.querySelector('.process-title');
+        titleEl.textContent = process['Процесс'] || 'Без названия';
+        titleEl.setAttribute('data-process-id', process['ПроцессID']);
+
+        card.querySelector('.process-id').textContent = 'ID: ' + process['ПроцессID'];
+        card.querySelector('.process-group').textContent = getReferenceName('Группа', process['Группа']) || '—';
+        card.querySelector('.process-subjects').textContent = getReferenceName('Количество субъектов ПДн', process['Количество субъектов ПДн']) || '—';
+        card.querySelector('.process-date').textContent = process['Дата создания'] || '—';
+        card.querySelector('.process-creator').textContent = process['Имя'] || '—';
+
+        grid.append(card);
+    });
+
+    // Render pagination
+    renderPagination(totalPages);
+
+    // Show counter
+    counter.text('Показано ' + pageProcesses.length + ' из ' + filteredProcesses.length).show();
+}
+
+/**
+ * Render pagination controls
+ */
+function renderPagination(totalPages) {
+    const pagination = $('#pagination');
+    const nav = $('#paginationNav');
+
+    if (totalPages <= 1) {
+        nav.hide();
+        return;
+    }
+
+    pagination.empty();
+    nav.show();
+
+    // Previous button
+    pagination.append(
+        '<li class="page-item ' + (currentPage === 1 ? 'disabled' : '') + '">' +
+        '<a class="page-link" href="#" onclick="goToPage(' + (currentPage - 1) + '); return false;">&laquo;</a></li>'
+    );
+
+    // Page numbers
+    const pages = getVisiblePages(currentPage, totalPages);
+    pages.forEach(function(page) {
+        if (page === '...') {
+            pagination.append('<li class="page-item disabled"><span class="page-link">...</span></li>');
+        } else {
+            pagination.append(
+                '<li class="page-item ' + (page === currentPage ? 'active' : '') + '">' +
+                '<a class="page-link" href="#" onclick="goToPage(' + page + '); return false;">' + page + '</a></li>'
+            );
+        }
+    });
+
+    // Next button
+    pagination.append(
+        '<li class="page-item ' + (currentPage === totalPages ? 'disabled' : '') + '">' +
+        '<a class="page-link" href="#" onclick="goToPage(' + (currentPage + 1) + '); return false;">&raquo;</a></li>'
+    );
+}
+
+/**
+ * Calculate visible page numbers
+ */
+function getVisiblePages(current, total) {
+    const pages = [];
+
+    if (total <= 7) {
+        for (let i = 1; i <= total; i++) pages.push(i);
+    } else {
+        if (current <= 4) {
+            for (let i = 1; i <= 5; i++) pages.push(i);
+            pages.push('...');
+            pages.push(total);
+        } else if (current >= total - 3) {
+            pages.push(1);
+            pages.push('...');
+            for (let i = total - 4; i <= total; i++) pages.push(i);
+        } else {
+            pages.push(1);
+            pages.push('...');
+            for (let i = current - 1; i <= current + 1; i++) pages.push(i);
+            pages.push('...');
+            pages.push(total);
+        }
+    }
+
+    return pages;
+}
+
+/**
+ * Navigate to specific page
+ */
+function goToPage(page) {
+    const totalPages = Math.ceil(filteredProcesses.length / itemsPerPage);
+    if (page >= 1 && page <= totalPages) {
+        currentPage = page;
+        renderProcesses();
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+}
+
+/**
+ * Setup search input listener
+ */
+function setupSearchListener() {
+    let debounceTimer;
+    $('#searchInput').on('input', function() {
+        clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(function() {
+            performSearch();
+        }, 300);
+    });
+}
+
+/**
+ * Perform search across all fields
+ */
+function performSearch() {
+    const query = $('#searchInput').val().toLowerCase().trim();
+
+    if (!query) {
+        filteredProcesses = allProcesses;
+    } else {
+        filteredProcesses = allProcesses.filter(function(process) {
+            return Object.values(process).some(function(value) {
+                return String(value).toLowerCase().includes(query);
+            });
+        });
+    }
+
+    currentPage = 1;
+    renderProcesses();
+}
+
+/**
+ * Open form for adding new process
+ */
+function openAddForm() {
+    editingProcessId = null;
+    $('#processFormModalLabel').text('Новый процесс');
+    resetForm();
+    loadReferencesIfNeeded(function() {
+        populateFormSelects();
+        // Set default status to "Проект" (372)
+        $('#processStatus').val('372');
+        // Set current user as initiator
+        if (uid) {
+            $('#processInitiator').val(uid);
+        }
+        $('#processFormModal').modal('show');
+    });
+}
+
+/**
+ * Open form for editing existing process
+ */
+function openEditForm(element) {
+    const processId = $(element).attr('data-process-id');
+    const process = allProcesses.find(function(p) {
+        return p['ПроцессID'] === processId;
+    });
+
+    if (!process) {
+        showNotification('Процесс не найден', 'error');
+        return;
+    }
+
+    editingProcessId = processId;
+    $('#processFormModalLabel').text('Редактирование процесса');
+    resetForm();
+
+    loadReferencesIfNeeded(function() {
+        populateFormSelects(process);
+        fillFormWithProcess(process);
+        $('#processFormModal').modal('show');
+    });
+}
+
+/**
+ * Fill form fields with process data
+ */
+function fillFormWithProcess(process) {
+    $('#processName').val(decodeHtmlEntities(process['Процесс'] || ''));
+    $('#processStatus').val(process['Статус'] || '');
+    $('#processGroup').val(process['Группа'] || '');
+    $('#processParent').val(process['Родительский (Процесс)'] || '');
+    $('#processInitiator').val(process['Инициатор (Пользователь)'] || '');
+    $('#processProduct').val(process['Продукт'] || '');
+    $('#processService').val(process['Сервис'] || '');
+    $('#processIS').val(process['ИС'] || '');
+    $('#processPurpose').val(process['Цель обработки ПДн'] || '');
+    $('#processMicroPurpose').val(process['Микроцель обработки ПДн'] || '');
+
+    // Handle multiselect for categories
+    const categories = process['Категории субъектов ПДн'];
+    if (categories) {
+        const categoryIds = categories.split(',').map(function(s) { return s.trim(); });
+        $('#processSubjectCategories').val(categoryIds);
+    }
+
+    $('#processSubjectsCount').val(process['Количество субъектов ПДн'] || '');
+    $('#processLegalBasis').val(process['Основание обработки ПДн'] || '');
+    $('#processLegalAct').val(decodeHtmlEntities(process['Реквизиты нормативного правового акта'] || ''));
+    $('#processMethod').val(process['Способ обработки ПДн'] || '');
+    $('#processTerm').val(process['Срок обработки ПДн'] || '');
+    $('#processDestruction').val(decodeHtmlEntities(process['Порядок уничтожения ПДн'] || ''));
+}
+
+/**
+ * Reset form to initial state
+ */
+function resetForm() {
+    $('#processName').val('');
+    $('#processStatus').val('');
+    $('#processGroup').val('');
+    $('#processParent').val('');
+    $('#processInitiator').val('');
+    $('#processProduct').val('');
+    $('#processService').val('');
+    $('#processIS').val('');
+    $('#processPurpose').val('');
+    $('#processMicroPurpose').val('');
+    $('#processSubjectCategories').val([]);
+    $('#processSubjectsCount').val('');
+    $('#processLegalBasis').val('');
+    $('#processLegalAct').val('');
+    $('#processMethod').val('');
+    $('#processTerm').val('');
+    $('#processDestruction').val('');
+    $('#processDestructionFile').val('');
+    $('#formError').hide();
+    $('#general-tab').tab('show');
+}
+
+/**
+ * Load references if not already loaded
+ */
+function loadReferencesIfNeeded(callback) {
+    if (referencesLoaded) {
+        callback();
+        return;
+    }
+
+    const promises = REFERENCE_NAMES.map(function(name) {
+        return $.ajax({
+            url: '/' + db + '/report/' + encodeURIComponent(name) + '?JSON_KV',
+            method: 'GET',
+            dataType: 'json'
+        }).then(function(data) {
+            return { name: name, data: data || [] };
+        }).catch(function() {
+            return { name: name, data: [] };
+        });
+    });
+
+    Promise.all(promises).then(function(results) {
+        results.forEach(function(result) {
+            references[result.name] = result.data;
+        });
+        referencesLoaded = true;
+        callback();
+    });
+}
+
+/**
+ * Populate form select elements with reference data
+ */
+function populateFormSelects(excludeProcess) {
+    populateSelect('#processStatus', 'Статус');
+    populateSelect('#processGroup', 'Группа');
+    populateSelect('#processInitiator', 'Инициатор');
+    populateSelect('#processProduct', 'Продукт');
+    populateSelect('#processService', 'Сервис');
+    populateSelect('#processIS', 'ИС');
+    populateSelect('#processPurpose', 'Цель обработки ПДн');
+    populateSelect('#processMicroPurpose', 'Микроцель обработки ПДн');
+    populateSelect('#processSubjectCategories', 'Категории субъектов ПДн');
+    populateSelect('#processSubjectsCount', 'Количество субъектов ПДн');
+    populateSelect('#processLegalBasis', 'Основание обработки ПДн');
+    populateSelect('#processMethod', 'Способ обработки ПДн');
+    populateSelect('#processTerm', 'Срок обработки ПДн');
+
+    // Populate parent process select
+    const parentSelect = $('#processParent');
+    parentSelect.empty().append('<option value="">— Выберите —</option>');
+    allProcesses.forEach(function(p) {
+        if (!excludeProcess || p['ПроцессID'] !== excludeProcess['ПроцессID']) {
+            parentSelect.append('<option value="' + p['ПроцессID'] + '">' + escapeHtml(p['Процесс']) + '</option>');
+        }
+    });
+}
+
+/**
+ * Populate a single select element
+ */
+function populateSelect(selector, refName) {
+    const select = $(selector);
+    const data = references[refName] || [];
+    const isMultiple = select.prop('multiple');
+
+    select.empty();
+    if (!isMultiple) {
+        select.append('<option value="">— Выберите —</option>');
+    }
+
+    data.forEach(function(item) {
+        const idField = getIdField(item);
+        const valueField = getValueField(item);
+        if (idField && valueField) {
+            select.append('<option value="' + item[idField] + '">' + escapeHtml(item[valueField]) + '</option>');
+        }
+    });
+}
+
+/**
+ * Get ID field name from reference item
+ */
+function getIdField(item) {
+    const keys = Object.keys(item);
+    return keys.find(function(k) { return k.endsWith('ID'); }) || keys[1] || keys[0];
+}
+
+/**
+ * Get value field name from reference item
+ */
+function getValueField(item) {
+    const keys = Object.keys(item);
+    return keys.find(function(k) { return !k.endsWith('ID'); }) || keys[0];
+}
+
+/**
+ * Get reference display name by ID
+ */
+function getReferenceName(refName, id) {
+    if (!id || !references[refName]) return null;
+    const item = references[refName].find(function(r) {
+        const idField = getIdField(r);
+        return r[idField] == id;
+    });
+    if (!item) return null;
+    return item[getValueField(item)];
+}
+
+/**
+ * Save process (create or update)
+ */
+function saveProcess() {
+    const btn = $('#saveProcessBtn');
+    const spinner = btn.find('.spinner-border');
+    const btnText = btn.find('.btn-text');
+
+    // Validate
+    const processName = $('#processName').val().trim();
+    if (!processName) {
+        $('#formError').text('Укажите название процесса').show();
+        $('#general-tab').tab('show');
+        return;
+    }
+
+    // Show loading state
+    btn.prop('disabled', true);
+    spinner.removeClass('d-none');
+    btnText.text('Сохранение...');
+    $('#formError').hide();
+
+    // Collect form data
+    const formData = {
+        _xsrf: xsrf
+    };
+
+    formData[FIELD_IDS.process] = processName;
+    formData[FIELD_IDS.status] = $('#processStatus').val() || '';
+    formData[FIELD_IDS.group] = $('#processGroup').val() || '';
+    formData[FIELD_IDS.parent] = $('#processParent').val() || '';
+    formData[FIELD_IDS.initiator] = $('#processInitiator').val() || '';
+    formData[FIELD_IDS.product] = $('#processProduct').val() || '';
+    formData[FIELD_IDS.service] = $('#processService').val() || '';
+    formData[FIELD_IDS.is] = $('#processIS').val() || '';
+    formData[FIELD_IDS.purpose] = $('#processPurpose').val() || '';
+    formData[FIELD_IDS.microPurpose] = $('#processMicroPurpose').val() || '';
+
+    // Handle multiselect
+    const categories = $('#processSubjectCategories').val() || [];
+    formData[FIELD_IDS.subjectCategories] = categories.join(',');
+
+    formData[FIELD_IDS.subjectsCount] = $('#processSubjectsCount').val() || '';
+    formData[FIELD_IDS.legalBasis] = $('#processLegalBasis').val() || '';
+    formData[FIELD_IDS.legalAct] = $('#processLegalAct').val() || '';
+    formData[FIELD_IDS.method] = $('#processMethod').val() || '';
+    formData[FIELD_IDS.term] = $('#processTerm').val() || '';
+    formData[FIELD_IDS.destruction] = $('#processDestruction').val() || '';
+
+    // Determine URL
+    let url;
+    if (editingProcessId) {
+        url = '/' + db + '/_m_save/' + editingProcessId + '?JSON';
+    } else {
+        url = '/' + db + '/_m_new/294?JSON&up=1';
+    }
+
+    $.ajax({
+        url: url,
+        method: 'POST',
+        data: formData,
+        dataType: 'json',
+        success: function(response) {
+            $('#processFormModal').modal('hide');
+            showNotification(editingProcessId ? 'Процесс сохранен' : 'Процесс создан', 'success');
+            loadProcesses();
+        },
+        error: function(xhr, status, error) {
+            console.error('Error saving process:', error);
+            $('#formError').text('Ошибка сохранения: ' + error).show();
+        },
+        complete: function() {
+            btn.prop('disabled', false);
+            spinner.addClass('d-none');
+            btnText.text('Сохранить');
+        }
+    });
+}
+
+/**
+ * Show notification message
+ */
+function showNotification(message, type) {
+    const panel = $('#notificationPanel');
+    const msgEl = $('#notificationMessage');
+
+    panel.removeClass('error warning info success');
+    if (type) {
+        panel.addClass(type);
+    }
+
+    msgEl.text(message);
+    panel.addClass('show');
+
+    setTimeout(function() {
+        panel.removeClass('show');
+    }, 3000);
+}
+
+/**
+ * Show loading state
+ */
+function showLoadingState() {
+    $('#loadingState').show();
+    $('#processGrid').hide();
+    $('#emptyState').hide();
+    $('#noResultsState').hide();
+    $('#paginationNav').hide();
+    $('#itemsCounter').hide();
+}
+
+/**
+ * Hide loading state
+ */
+function hideLoadingState() {
+    $('#loadingState').hide();
+}
+
+/**
+ * Escape HTML entities
+ */
+function escapeHtml(text) {
+    if (!text) return '';
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+}
+
+/**
+ * Decode HTML entities
+ */
+function decodeHtmlEntities(text) {
+    if (!text) return '';
+    const div = document.createElement('div');
+    div.innerHTML = text;
+    return div.textContent;
+}


### PR DESCRIPTION
## Summary
- Convert Vue.js application to Integram template format following the pattern from [ideav/Rivojy](https://github.com/ideav/Rivojy)
- Add `process.html` template for the process list workplace
- Add `process.js` with API logic for CRUD operations
- Add `process.css` with responsive styles

## Template Structure
Templates follow Integram constructor pattern:
- CSS/JS loaded from `/download/{db}/` path
- Uses jQuery and Bootstrap (provided by main.html)
- XSRF token authentication for POST requests
- Guest user redirect to login page
- Global variables: `db`, `xsrf`, `uid` from main.html

## API Endpoints
- `GET report/480?JSON_KV` - fetch processes list
- `GET report/{field}?JSON_KV` - fetch reference lists (Статус, Группа, etc.)
- `POST _m_new/294?JSON&up=1` - create new process
- `POST _m_save/{id}?JSON` - update existing process

## Features
- Process cards with search across all fields
- Pagination (20 items per page)
- Modal form with 4 tabs for editing
- Reference dropdowns loaded from API
- Responsive design for mobile

Closes #3

## Test plan
- [ ] Deploy templates to Integram server
- [ ] Verify process list loads correctly
- [ ] Test search functionality
- [ ] Test pagination
- [ ] Test add new process
- [ ] Test edit existing process
- [ ] Test on mobile devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)