### PR TITLE
feat: Add "Иное" (Other) option to legal basis dropdown

### DIFF
--- a/templates/process.html
+++ b/templates/process.html
@@ -169,8 +169,12 @@
                             <select class="form-control" id="processSubjectsCount"></select>
                         </div>
                         <div class="form-group">
-                            <label for="processLegalBasis">Основание обработки ПДн</label>
+                            <label for="processLegalBasis">Основание обработки ПДн *</label>
                             <select class="form-control" id="processLegalBasis"></select>
+                        </div>
+                        <div class="form-group" id="legalBasisOtherGroup" style="display: none;">
+                            <label for="processLegalBasisOther">Укажите иное основание *</label>
+                            <textarea class="form-control" id="processLegalBasisOther" rows="2" placeholder="Введите альтернативное основание обработки ПДн"></textarea>
                         </div>
                         <div class="form-group">
                             <label for="processLegalAct">Реквизиты нормативного правового акта</label>


### PR DESCRIPTION
## Summary
- Add "Иное" (Other) option at the end of "Основание обработки ПДн" dropdown
- When "Иное" is selected, display a textarea for entering alternative legal basis
- Save alternative value as `t600` parameter (not `t336`)
- Add validation: legal basis is mandatory, and selecting "Иное" requires filling the alternative text

## Changes
- `process.html`: Added `#legalBasisOtherGroup` with textarea for alternative legal basis
- `process.js`:
  - Added `LEGAL_BASIS_OTHER_VALUE` constant
  - Added `t600` (legalBasisOther) to FIELD_IDS
  - Added `toggleLegalBasisOther()` function to show/hide textarea
  - Updated `populateSelect()` to add "Иное" option for legal basis
  - Updated `fillFormWithProcess()` to handle "Иное" when editing
  - Updated `resetForm()` to clear and hide the other field
  - Updated `saveProcess()` with validation and conditional save logic

## Validation Rules
1. Legal basis field is mandatory
2. If "Иное" is selected, the alternative text field must be filled
3. Just selecting "Иное" without text is not valid

Closes #7

## Test plan
- [ ] Verify "Иное" option appears at the end of legal basis dropdown
- [ ] Select "Иное" → textarea appears
- [ ] Select another option → textarea hides and clears
- [ ] Try to save with empty legal basis → validation error
- [ ] Try to save with "Иное" selected but empty text → validation error
- [ ] Save with "Иное" and text → verify t600 is saved, t336 is empty
- [ ] Edit process with "Иное" → verify textarea shows with saved value

🤖 Generated with [Claude Code](https://claude.com/claude-code)