### PR TITLE
Fix display mode threshold for tab data (issue #14)

### DIFF
--- a/templates/process.js
+++ b/templates/process.js
@@ -857,7 +857,7 @@ function renderTabData(tabName, items, processId) {
     // Determine columns (exclude ID columns)
     const firstItem = items[0];
     const columns = Object.keys(firstItem).filter(key => !key.endsWith('ID'));
-    const displayMode = columns.length < 3 ? 'table' : 'cards';
+    const displayMode = columns.length <= 3 ? 'table' : 'cards';
 
     // Reset state
     tabPaginationState[tabName].page = 1;
@@ -1035,7 +1035,7 @@ function filterTabData(tabName, query) {
     const items = state.data;
     const firstItem = items[0];
     const columns = Object.keys(firstItem).filter(key => !key.endsWith('ID'));
-    const displayMode = columns.length < 3 ? 'table' : 'cards';
+    const displayMode = columns.length <= 3 ? 'table' : 'cards';
 
     let html = '<div class="data-tab-wrapper">';
 


### PR DESCRIPTION
## Problem
The ПДн and Передача tabs were displaying as cards instead of tables even though they contain exactly 3 or fewer data fields.

## Root Cause
The display mode logic used  which meant:
- 1-2 columns = table
- 3+ columns = cards

This caused tabs with exactly 3 fields to incorrectly display as cards.

## Solution
Changed the threshold from  to :
- **1-3 columns** = table view
- **4+ columns** = card view

This ensures all tabs with 3 or fewer fields display in the more compact table format, while tabs with more fields use the card format.

## Changes
- Updated display mode threshold in  function
- Updated display mode threshold in  function
- Both locations now consistently use  for table display

## Testing
- ПДн tab should now display as table (if it has <= 3 fields)
- Передача tab should now display as table (if it has <= 3 fields)
- Other tabs with > 3 fields continue to display as cards
- Pagination and search functionality unchanged

Fixes #14