### PR TITLE
Remove chevron navigation buttons (issue #22)

### DIFF
--- a/templates/process.css
+++ b/templates/process.css
@@ -137,55 +137,6 @@
 }
 
 /* Material Design Tab Styles */
-.nav-tabs-wrapper {
-    display: flex;
-    align-items: center;
-    gap: 0;
-    border-bottom: 1px solid #e0e0e0;
-    position: relative;
-}
-
-.nav-tabs-scroll-btn {
-    position: absolute;
-    width: 36px;
-    height: 48px;
-    background: none;
-    border: none;
-    color: #616161;
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: opacity 0.2s ease;
-    opacity: 0;
-    pointer-events: none;
-    font-size: 18px;
-    z-index: 10;
-    top: 0;
-}
-
-.nav-tabs-scroll-btn#formTabsScrollLeft {
-    left: 0;
-}
-
-.nav-tabs-scroll-btn#formTabsScrollRight {
-    right: 0;
-}
-
-.nav-tabs-scroll-btn:hover:not(.hidden) {
-    color: #007bff;
-    background-color: rgba(0, 123, 255, 0.1);
-}
-
-.nav-tabs-scroll-btn.visible {
-    opacity: 1;
-    pointer-events: auto;
-}
-
-.nav-tabs-scroll-btn.hidden {
-    display: none;
-}
-
 .nav-tabs {
     display: flex;
     flex-wrap: nowrap;
@@ -193,7 +144,7 @@
     -webkit-overflow-scrolling: touch;
     gap: 0;
     scroll-behavior: smooth;
-    flex: 1;
+    border-bottom: 1px solid #e0e0e0;
 
     /* Hide scrollbars completely */
     scrollbar-width: none;  /* Firefox */

--- a/templates/process.html
+++ b/templates/process.html
@@ -91,10 +91,8 @@
                 </button>
             </div>
             <div class="modal-body">
-                <!-- Tabs with scroll buttons -->
-                <div class="nav-tabs-wrapper" id="formTabsWrapper">
-                    <button class="nav-tabs-scroll-btn" id="formTabsScrollLeft" onclick="scrollFormTabs(-120)" title="Scroll left">◀</button>
-                    <ul class="nav nav-tabs" id="formTabs" role="tablist">
+                <!-- Tabs -->
+                <ul class="nav nav-tabs" id="formTabs" role="tablist">
                     <li class="nav-item">
                         <a class="nav-link active" id="general-tab" data-toggle="tab" href="#generalTab" role="tab">Общая информация</a>
                     </li>
@@ -120,8 +118,6 @@
                         <a class="nav-link" id="transfer-tab" data-toggle="tab" href="#transferTab" role="tab">Передача</a>
                     </li>
                 </ul>
-                    <button class="nav-tabs-scroll-btn" id="formTabsScrollRight" onclick="scrollFormTabs(120)" title="Scroll right">▶</button>
-                </div>
 
                 <!-- Tab Content -->
                 <div class="tab-content pt-3" id="formTabContent">

--- a/templates/process.js
+++ b/templates/process.js
@@ -77,7 +77,6 @@ $(document).ready(function() {
     setupSearchListener();
     setupDependentDropdowns();
     setupDataTabListeners();
-    setupFormTabsScrolling();
 });
 
 /**
@@ -1121,128 +1120,6 @@ function openTabRowEditModal(tabName, itemData) {
     // TODO: Open edit modal with item data
     // For now, show placeholder
     showNotification('Функция редактирования в разработке. Tab: ' + tabName + ', ID: ' + itemId, 'info');
-}
-
-/**
- * Setup form tabs scrolling with chevron buttons
- */
-function setupFormTabsScrolling() {
-    const tabsContainer = $('#formTabs');
-    const leftBtn = $('#formTabsScrollLeft');
-    const rightBtn = $('#formTabsScrollRight');
-
-    if (!tabsContainer.length) return;
-
-    // Check scroll state on load and window resize
-    function updateScrollButtons() {
-        setTimeout(function() {
-            const tabs = tabsContainer[0];
-            const hasScroll = tabs.scrollWidth > tabs.clientWidth;
-            const isAtStart = tabs.scrollLeft === 0;
-            const isAtEnd = tabs.scrollLeft + tabs.clientWidth >= tabs.scrollWidth - 5;
-
-            if (hasScroll) {
-                if (isAtStart) {
-                    leftBtn.addClass('hidden').removeClass('visible');
-                } else {
-                    leftBtn.addClass('visible').removeClass('hidden');
-                }
-
-                if (isAtEnd) {
-                    rightBtn.addClass('hidden').removeClass('visible');
-                } else {
-                    rightBtn.addClass('visible').removeClass('hidden');
-                }
-            } else {
-                leftBtn.addClass('hidden').removeClass('visible');
-                rightBtn.addClass('hidden').removeClass('visible');
-            }
-        }, 100);
-    }
-
-    // Update on scroll
-    tabsContainer.on('scroll', updateScrollButtons);
-
-    // Update on window resize
-    $(window).on('resize', updateScrollButtons);
-
-    // Update on modal show
-    $('#processFormModal').on('shown.bs.modal', updateScrollButtons);
-
-    // Handle tab click to show full tab and partial next
-    tabsContainer.find('.nav-link').on('click', function() {
-        setTimeout(function() {
-            const clickedTab = tabsContainer.find('.nav-link.active');
-            if (clickedTab.length === 0) return;
-
-            const container = tabsContainer[0];
-            const tab = clickedTab[0];
-            const parent = tab.closest('.nav-item');
-
-            if (!parent) return;
-
-            // Calculate the position to scroll so the tab is fully visible and next tab peeks 30px
-            const tabOffsetInContainer = parent.offsetLeft;
-            const tabWidth = parent.offsetWidth;
-            const containerWidth = container.clientWidth;
-            const scrollWidth = container.scrollWidth;
-
-            // Calculate target scroll position
-            let targetScroll = container.scrollLeft + parent.offsetLeft - container.scrollLeft;
-
-            // If there's a next tab, ensure it peeks 30px
-            const nextTab = parent.nextElementSibling;
-            if (nextTab) {
-                const peekDistance = 30;
-                // Position so current tab is fully visible and next peeks by 30px
-                targetScroll = parent.offsetLeft + tabWidth + peekDistance - containerWidth;
-            } else {
-                // Last tab - just scroll to make it fully visible
-                targetScroll = parent.offsetLeft + tabWidth - containerWidth;
-            }
-
-            // Clamp to valid scroll range
-            targetScroll = Math.max(0, Math.min(targetScroll, scrollWidth - containerWidth));
-
-            // Smooth scroll to target
-            tabsContainer.animate({ scrollLeft: targetScroll }, 300, function() {
-                updateScrollButtons();
-            });
-        }, 0);
-    });
-
-    // Initial check
-    updateScrollButtons();
-}
-
-/**
- * Scroll form tabs
- */
-function scrollFormTabs(distance) {
-    const tabsContainer = $('#formTabs');
-    if (!tabsContainer.length) return;
-
-    const currentScroll = tabsContainer.scrollLeft();
-    tabsContainer.animate({ scrollLeft: currentScroll + distance }, 300);
-
-    // Update button states after scroll
-    setTimeout(function() {
-        const tabs = tabsContainer[0];
-        const isAtStart = tabs.scrollLeft === 0;
-        const isAtEnd = tabs.scrollLeft + tabs.clientWidth >= tabs.scrollWidth - 5;
-
-        if (isAtStart) {
-            $('#formTabsScrollLeft').addClass('hidden').removeClass('visible');
-        } else {
-            $('#formTabsScrollLeft').addClass('visible').removeClass('hidden');
-        }
-
-        if (isAtEnd) {
-            $('#formTabsScrollRight').addClass('hidden').removeClass('visible');
-        } else {
-            $('#formTabsScrollRight').addClass('visible').removeClass('hidden');
-        }
-    }, 300);
 }
 
 /**


### PR DESCRIPTION
## Summary

Removes all chevron navigation buttons and related smart scrolling functionality as requested in issue #22. The tabs now use native browser horizontal scrolling.

## Changes Made

### templates/process.html
- Removed `nav-tabs-wrapper` container div
- Removed left chevron button (`<button id="formTabsScrollLeft">◀</button>`)
- Removed right chevron button (`<button id="formTabsScrollRight">▶</button>`)
- Simplified to just have `<ul class="nav nav-tabs">` element

### templates/process.css
- Removed all `.nav-tabs-wrapper` styling (flex container, positioning context)
- Removed all `.nav-tabs-scroll-btn` styling (absolute positioning, chevron button styles)
- Removed `.nav-tabs-scroll-btn#formTabsScrollLeft` positioning
- Removed `.nav-tabs-scroll-btn#formTabsScrollRight` positioning
- Removed `.nav-tabs-scroll-btn:hover` hover effects
- Removed `.nav-tabs-scroll-btn.visible` and `.nav-tabs-scroll-btn.hidden` state classes
- Added `border-bottom: 1px solid #e0e0e0` directly to `.nav-tabs`

### templates/process.js
- Removed `setupFormTabsScrolling()` function (120+ lines)
  - Removed chevron visibility detection logic
  - Removed smart tab scrolling with 30px peek behavior
  - Removed scroll state tracking
- Removed `scrollFormTabs()` function (25 lines)
- Removed `setupFormTabsScrolling()` call from document ready handler

## User Experience

✨ **Native Scrolling**:
- Horizontal scroll is available on all browsers
- Desktop users can scroll tabs with mouse wheel or trackpad
- Touch device users can drag tabs to scroll
- Scrollbars are hidden for cleaner appearance

## Testing Checklist

- [ ] Open process form modal with many tabs
- [ ] Verify tabs can be scrolled horizontally (drag on desktop, touch on mobile)
- [ ] Verify no chevron buttons appear
- [ ] Verify no console errors
- [ ] Test on narrow viewport (tabs overflow)
- [ ] Test on wide viewport (all tabs visible)