### PR TITLE
Fix smart scroll and layout for issue #24

### DIFF
--- a/src/components/ProcessList.vue
+++ b/src/components/ProcessList.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed } from 'vue';
+import { ref, computed, nextTick } from 'vue';
 import ProcessCard from './ProcessCard.vue';
 
 const props = defineProps({
@@ -75,6 +75,13 @@ const visiblePages = computed(() => {
 function goToPage(page) {
   if (page !== '...' && page >= 1 && page <= totalPages.value) {
     currentPage.value = page;
+    // Scroll cards grid into view after page change
+    nextTick(() => {
+      const cardsGrid = document.querySelector('.cards-grid');
+      if (cardsGrid) {
+        cardsGrid.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
+    });
   }
 }
 
@@ -160,12 +167,11 @@ function onSearch() {
   display: flex;
   gap: 16px;
   align-items: center;
-  flex-wrap: wrap;
 }
 
 .search-box {
   flex: 1;
-  min-width: 200px;
+  min-width: 0;
 }
 
 .search-input {


### PR DESCRIPTION
## Summary
Resolves #24 by fixing two issues:

1. **Smart scroll fix**: When navigating to different pages, the cards grid now smoothly scrolls into view, ensuring that previously selected items are visible on the new page.
2. **Layout fix**: Removed `flex-wrap: wrap` from the header and adjusted `min-width` to ensure the Add button and filter field stay on one line.

## Changes
- Added `nextTick` import and implemented smooth scroll behavior when changing pages
- Updated `.list-header` CSS to prevent wrapping
- Changed `.search-box` `min-width` from `200px` to `0` to allow proper flex shrinking

## Testing
- Verify pagination scrolls smoothly to show the grid when navigating pages
- Check that the Add button and search field remain on the same line at all screen sizes