### PR TITLE
Fix passive event listener warning for tabs horizontal scrolling

### DIFF
--- a/templates/process.js
+++ b/templates/process.js
@@ -84,16 +84,23 @@ $(document).ready(function() {
  * Setup horizontal scrolling for tabs using mouse wheel
  */
 function setupTabsHorizontalScroll() {
-    $(document).on('wheel', '#formTabs', function(event) {
-        event.preventDefault();
+    const tabsElement = document.getElementById('formTabs');
+    if (!tabsElement) return;
 
-        // Get scroll container
-        const container = this;
-        const scrollAmount = event.originalEvent.deltaY > 0 ? 100 : -100;
+    const handleWheel = function(event) {
+        if (event.target.closest('#formTabs')) {
+            event.preventDefault();
 
-        // Apply horizontal scroll
-        container.scrollLeft += scrollAmount;
-    });
+            // Get scroll container
+            const scrollAmount = event.deltaY > 0 ? 100 : -100;
+
+            // Apply horizontal scroll
+            tabsElement.scrollLeft += scrollAmount;
+        }
+    };
+
+    // Use { passive: false } to allow preventDefault()
+    tabsElement.addEventListener('wheel', handleWheel, { passive: false });
 }
 
 /**


### PR DESCRIPTION
## Summary
Resolves #29 by fixing the Chrome warning about passive event listeners when scrolling tabs.

## Problem
The previous implementation used jQuery's `.on()` method to attach a wheel event listener, which by default treats event listeners as passive. When calling `event.preventDefault()` on a passive event listener, Chrome throws a warning:

```
[Intervention] Unable to preventDefault inside passive event listener due to target being treated as passive
```

## Solution
Replaced the jQuery event handler with native JavaScript `addEventListener()` and added the `{ passive: false }` option, which allows calling `preventDefault()` without warnings.

## Changes
- Replaced `$(document).on('wheel', '#formTabs', ...)` with native `addEventListener()`
- Added `{ passive: false }` option to the event listener
- Used `event.target.closest('#formTabs')` for proper event delegation
- Simplified the event handler logic

## Technical Details
- Native `addEventListener()` with `{ passive: false }` allows `preventDefault()` to work without browser warnings
- The `event.target.closest()` ensures we only handle events within the tabs container
- The `scrollLeft` property is still used to scroll horizontally

## Testing
- Verify no console warnings when scrolling tabs with mouse wheel
- Verify horizontal scrolling still works correctly
- Test in Chrome, Firefox, and Safari