### PR TITLE
Add dic%20 prefix to reference data queries

### DIFF
--- a/templates/process.js
+++ b/templates/process.js
@@ -529,7 +529,7 @@ function loadReferencesIfNeeded(callback) {
 
     const promises = REFERENCE_NAMES.map(function(name) {
         return $.ajax({
-            url: '/' + db + '/report/' + encodeURIComponent(name) + '?JSON_KV',
+            url: '/' + db + '/report/dic%20' + encodeURIComponent(name) + '?JSON_KV',
             method: 'GET',
             dataType: 'json'
         }).then(function(data) {


### PR DESCRIPTION
## Summary
Resolves #31 by adding the `dic%20` prefix to reference data API queries in the Integram constructor template.

## Problem
Reference data queries were using the URL format:
```
/db/report/{reference_name}?JSON_KV
```

According to the Integram constructor convention, dictionary/reference table queries should use the prefix `dic%20`:
```
/db/report/dic%20{reference_name}?JSON_KV
```

## Solution
Updated the `loadReferencesIfNeeded()` function to prepend `dic%20` to all reference data API calls.

## Changes
- Modified `templates/process.js` line 532
- Added `dic%20` prefix to the report URL in `loadReferencesIfNeeded()` function
- This affects all reference data loads (Статус, Группа, Инициатор, etc.)

## Example URLs
Before:
```
GET /db/report/Статус?JSON_KV
```

After:
```
GET /db/report/dic%20Статус?JSON_KV
```

## Technical Details
- The `%20` is the URL-encoded space character
- This aligns with Integram constructor naming conventions for reference tables
- The `encodeURIComponent()` function is still applied after the prefix for proper encoding of the reference name

## Testing
- Verify reference data loads correctly when opening the form
- Check browser network tab to confirm URLs have `dic%20` prefix
- Ensure all dropdown selects populate correctly