### PR TITLE
Fix: Add button and filter field on same line on data tabs

### DIFF
--- a/templates/process.css
+++ b/templates/process.css
@@ -322,6 +322,13 @@ select.form-control[multiple] {
     }
 }
 
+/* Data Tab Toolbar - button and filter on same line */
+.data-tab-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
 /* Bootstrap Icon placeholder (if not using Bootstrap Icons) */
 .bi-plus-circle::before {
     content: "+";


### PR DESCRIPTION
## Summary
- Adds CSS flexbox layout to `.data-tab-toolbar` class
- Makes the "Добавить" (Add) button and filter input field display on the same line
- Affects tabs: ПДн, Экспертиза, Риски, and Передача on the process editing form

Fixes #33

## Test plan
- [ ] Open process editing form
- [ ] Navigate to ПДн, Экспертиза, Риски, or Передача tabs
- [ ] Verify "Добавить" button and filter field are on the same line

🤖 Generated with [Claude Code](https://claude.com/claude-code)