### PR TITLE
Загрузка справочников перед отрисовкой плашек процессов

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/ideav/pdn/issues/37
-Your prepared branch: issue-37-c08038fa63df
-Your prepared working directory: /tmp/gh-issue-solver-1768497564304
-Your forked repository: konard/ideav-pdn
-Original repository (upstream): ideav/pdn
-
-Proceed.


### PR DESCRIPTION
## 🎯 Описание

Исправлена проблема с отображением значений справочников на плашках процессов.

### Проблема
Ранее на плашках процессов вместо названий справочных значений отображался символ "—", так как справочники (Группа, Количество субъектов ПДн) загружались только при открытии формы добавления/редактирования процесса, а не при первой отрисовке плашек.

### Решение
Теперь справочники загружаются сразу после получения списка процессов и перед первой отрисовкой плашек. Это обеспечивает правильное отображение названий вместо ID значений.

## 📋 Изменения

### `templates/process.js`
- Изменена функция `loadProcesses()`: добавлен вызов `loadReferencesIfNeeded()` перед `renderProcesses()`
- Справочники теперь загружаются асинхронно в параллель с помощью `Promise.all()`
- После загрузки справочников выполняется отрисовка плашек с правильными значениями

## ✅ Результат

- ✅ Поля "Группа" и "Количество субъектов ПДн" на плашках процессов отображают названия вместо "—"
- ✅ Справочники загружаются один раз при первой загрузке страницы
- ✅ Не нарушена работа пагинации и поиска
- ✅ Не нарушена работа формы добавления/редактирования (использует кэшированные справочники)

## 🔗 Связанные задачи
Fixes #37

---
*Создано автоматически AI issue solver*