### PR TITLE
Изменить плашки ПДн и Экспертизы

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,3 +31,16 @@ Proceed.
 
 
 Run timestamp: 2026-01-15T19:53:36.074Z
+
+---
+
+Issue to solve: https://github.com/ideav/pdn/issues/55
+Your prepared branch: issue-55-d56655003306
+Your prepared working directory: /tmp/gh-issue-solver-1768513305526
+Your forked repository: konard/ideav-pdn
+Original repository (upstream): ideav/pdn
+
+Proceed.
+
+
+Run timestamp: 2026-01-15T21:41:50.671Z

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,16 +31,3 @@ Proceed.
 
 
 Run timestamp: 2026-01-15T19:53:36.074Z
-
----
-
-Issue to solve: https://github.com/ideav/pdn/issues/55
-Your prepared branch: issue-55-d56655003306
-Your prepared working directory: /tmp/gh-issue-solver-1768513305526
-Your forked repository: konard/ideav-pdn
-Original repository (upstream): ideav/pdn
-
-Proceed.
-
-
-Run timestamp: 2026-01-15T21:41:50.671Z

--- a/templates/process.html
+++ b/templates/process.html
@@ -77,9 +77,11 @@
                 </div>
                 <div class="process-stats">
                     <div class="stat-badge stat-badge-pdn" title="Количество разных ПДн в процессе">
+                        <span class="stat-badge-label">ПДн:</span>
                         <span class="stat-badge-count process-pdn-count">0</span>
                     </div>
                     <div class="stat-badge stat-badge-expertise" title="Количество экспертиз, проведенных по процессу">
+                        <span class="stat-badge-label">Экспертизы:</span>
                         <span class="stat-badge-count process-expertise-count">0</span>
                     </div>
                 </div>


### PR DESCRIPTION
## Описание изменений

Добавлены текстовые подписи к плашкам статистики на карточках процессов согласно требованиям issue #55.

### Что изменено

**Файл:** `templates/process.html` (строки 78-87)

Добавлены подписи к плашкам:
- **ПДн:** — подпись перед количеством персональных данных
- **Экспертизы:** — подпись перед количеством экспертиз

### Детали реализации

#### До изменений:
```html
<div class="stat-badge stat-badge-pdn">
    <span class="stat-badge-count">0</span>
</div>
```

#### После изменений:
```html
<div class="stat-badge stat-badge-pdn">
    <span class="stat-badge-label">ПДн:</span>
    <span class="stat-badge-count">0</span>
</div>
```

### Визуальное отображение

Теперь плашки будут отображаться как:
- 🔴 **ПДн: 3** (красная плашка)
- 🔵 **Экспертизы: 1** (синяя плашка)

Вместо просто чисел **3** и **1**.

### Стилизация

Использован существующий CSS класс `.stat-badge-label` с настройками:
- Отступ справа: 6px
- Прозрачность: 0.85
- Цвет наследуется от родительского `.stat-badge-pdn` или `.stat-badge-expertise`

### Совместимость

✅ Все существующие стили сохранены  
✅ JavaScript код не требует изменений  
✅ Функциональность загрузки данных не затронута  

---

**Fixes:** #55

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>


Fixes ideav/pdn#55