### PR TITLE
Выровнять плашки ПДн и Экспертизы по нижнему краю

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,16 +31,3 @@ Proceed.
 
 
 Run timestamp: 2026-01-15T19:53:36.074Z
-
----
-
-Issue to solve: https://github.com/ideav/pdn/issues/57
-Your prepared branch: issue-57-25e8b4e8dc9a
-Your prepared working directory: /tmp/gh-issue-solver-1768513569498
-Your forked repository: konard/ideav-pdn
-Original repository (upstream): ideav/pdn
-
-Proceed.
-
-
-Run timestamp: 2026-01-15T21:46:14.798Z

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,3 +31,16 @@ Proceed.
 
 
 Run timestamp: 2026-01-15T19:53:36.074Z
+
+---
+
+Issue to solve: https://github.com/ideav/pdn/issues/57
+Your prepared branch: issue-57-25e8b4e8dc9a
+Your prepared working directory: /tmp/gh-issue-solver-1768513569498
+Your forked repository: konard/ideav-pdn
+Original repository (upstream): ideav/pdn
+
+Proceed.
+
+
+Run timestamp: 2026-01-15T21:46:14.798Z

--- a/templates/process.css
+++ b/templates/process.css
@@ -61,6 +61,11 @@
     border-left: 4px solid #007bff;
 }
 
+.process-card .card-body {
+    display: flex;
+    flex-direction: column;
+}
+
 .process-card:hover {
     transform: translateY(-3px);
     box-shadow: 0 6px 16px rgba(0, 0, 0, 0.12);
@@ -379,7 +384,7 @@ select.form-control[multiple] {
     display: flex;
     gap: 8px;
     justify-content: flex-end;
-    margin-top: 12px;
+    margin-top: auto;
     padding-top: 12px;
     border-top: 1px solid #f0f0f0;
 }


### PR DESCRIPTION
## Описание изменений

Плашки статистики (ПДн и Экспертизы) теперь выровнены по нижнему краю карточек процессов согласно требованиям issue #57.

### Что изменено

**Файл:** `templates/process.css`

Изменен CSS для выравнивания плашек к нижнему краю карточки:

#### 1. Добавлен flexbox layout для card-body (строки 64-67)
```css
.process-card .card-body {
    display: flex;
    flex-direction: column;
}
```

#### 2. Изменен margin-top для process-stats (строка 387)
```css
.process-stats {
    ...
    margin-top: auto;  /* было: margin-top: 12px; */
    ...
}
```

### Детали реализации

**До изменений:**
- Плашки располагались сразу после содержимого карточки с фиксированным отступом 12px
- При разной высоте содержимого карточек плашки находились на разных уровнях

**После изменений:**
- `.card-body` стал flex-контейнером с `flex-direction: column`
- `.process-stats` использует `margin-top: auto` для автоматического прижатия к нижнему краю
- Плашки теперь выровнены по нижнему краю независимо от высоты содержимого карточки

### Визуальный эффект

Теперь на странице со списком процессов плашки **ПДн:** и **Экспертизы:** будут выровнены по одной линии на всех карточках в одном ряду, даже если содержимое карточек имеет разную высоту.

### Совместимость

✅ Все существующие стили сохранены  
✅ Функциональность не затронута  
✅ Визуальное оформление плашек не изменено  
✅ Работает на всех размерах экрана  

---

**Fixes:** #57

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>


Fixes ideav/pdn#57